### PR TITLE
Fixed status effect icons Y offset for the 0.6 client.

### DIFF
--- a/graphics/sprites/icon-feather.xml
+++ b/graphics/sprites/icon-feather.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-feather.png" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="100"/>
+			<frame index="0" offsetY="0" delay="100"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-green-barrier.xml
+++ b/graphics/sprites/icon-green-barrier.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-green-barrier.png" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="0"/>
+			<frame index="0" offsetY="0" delay="0"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-haste-potion.xml
+++ b/graphics/sprites/icon-haste-potion.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-potion-c.png|G:#da69e5,ffdaff" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="100"/>
-			<frame index="1" offsetY="-12" delay="100"/>
-			<frame index="2" offsetY="-12" delay="100"/>
-			<frame index="3" offsetY="-12" delay="100"/>
+			<frame index="0" offsetY="0" delay="100"/>
+			<frame index="1" offsetY="0" delay="100"/>
+			<frame index="2" offsetY="0" delay="100"/>
+			<frame index="3" offsetY="0" delay="100"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-hidden.xml
+++ b/graphics/sprites/icon-hidden.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-hidden.png" width="12" height="12" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-15" delay="0"/>
+			<frame index="0" offsetY="3" delay="0"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-invisible.xml
+++ b/graphics/sprites/icon-invisible.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-invisible.png" width="16" height="24" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-10" delay="2000"/>
-			<frame index="1" offsetY="-10" delay="100"/>
-			<frame index="2" offsetY="-10" delay="100"/>
-			<frame index="3" offsetY="-10" delay="100"/>
-			<frame index="4" offsetY="-10" delay="100"/>
-			<frame index="0" offsetY="-10" delay="5000"/>
-			<frame index="1" offsetY="-10" delay="100"/>
-			<frame index="2" offsetY="-10" delay="100"/>
-			<frame index="3" offsetY="-10" delay="100"/>
-			<frame index="4" offsetY="-10" delay="100"/>
-			<frame index="0" offsetY="-10" delay="3000"/>
-			<frame index="7" offsetY="-10" delay="500"/>
-			<frame index="0" offsetY="-10" delay="3000"/>
-			<frame index="5" offsetY="-10" delay="50"/>
-			<frame index="6" offsetY="-10" delay="50"/>
-			<frame index="5" offsetY="-10" delay="50"/>
-			<frame index="6" offsetY="-10" delay="50"/>
-			<frame index="5" offsetY="-10" delay="50"/>
-			<frame index="6" offsetY="-10" delay="50"/>
-			<frame index="5" offsetY="-10" delay="50"/>
-			<frame index="6" offsetY="-10" delay="50"/>
-			<frame index="5" offsetY="-10" delay="50"/>
-			<frame index="6" offsetY="-10" delay="50"/>
-			<frame index="0" offsetY="-10" delay="3000"/>
-			<frame index="7" offsetY="-10" delay="300"/>
-			<frame index="0" offsetY="-10" delay="5000"/>
-			<frame index="7" offsetY="-10" delay="200"/>
+			<frame index="0" offsetY="0" delay="2000"/>
+			<frame index="1" offsetY="0" delay="100"/>
+			<frame index="2" offsetY="0" delay="100"/>
+			<frame index="3" offsetY="0" delay="100"/>
+			<frame index="4" offsetY="0" delay="100"/>
+			<frame index="0" offsetY="0" delay="5000"/>
+			<frame index="1" offsetY="0" delay="100"/>
+			<frame index="2" offsetY="0" delay="100"/>
+			<frame index="3" offsetY="0" delay="100"/>
+			<frame index="4" offsetY="0" delay="100"/>
+			<frame index="0" offsetY="0" delay="3000"/>
+			<frame index="7" offsetY="0" delay="500"/>
+			<frame index="0" offsetY="0" delay="3000"/>
+			<frame index="5" offsetY="0" delay="50"/>
+			<frame index="6" offsetY="0" delay="50"/>
+			<frame index="5" offsetY="0" delay="50"/>
+			<frame index="6" offsetY="0" delay="50"/>
+			<frame index="5" offsetY="0" delay="50"/>
+			<frame index="6" offsetY="0" delay="50"/>
+			<frame index="5" offsetY="0" delay="50"/>
+			<frame index="6" offsetY="0" delay="50"/>
+			<frame index="5" offsetY="0" delay="50"/>
+			<frame index="6" offsetY="0" delay="50"/>
+			<frame index="0" offsetY="0" delay="3000"/>
+			<frame index="7" offsetY="0" delay="300"/>
+			<frame index="0" offsetY="0" delay="5000"/>
+			<frame index="7" offsetY="0" delay="200"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-iron-potion.xml
+++ b/graphics/sprites/icon-iron-potion.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-potion-b.png|G:#c05000,f0a000,f0f09f" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12"/>
+			<frame index="0" offsetY="0"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-poison.xml
+++ b/graphics/sprites/icon-poison.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-poison.png" width="12" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="80"/>
-			<frame index="1" offsetY="-12" delay="80"/>
-			<frame index="2" offsetY="-12" delay="80"/>
-			<frame index="3" offsetY="-12" delay="80"/>
-			<frame index="4" offsetY="-12" delay="80"/>
-			<frame index="5" offsetY="-12" delay="80"/>
-			<frame index="6" offsetY="-12" delay="80"/>
-			<frame index="7" offsetY="-12" delay="80"/>
-			<frame index="8" offsetY="-12" delay="80"/>
+			<frame index="0" offsetY="0" delay="80"/>
+			<frame index="1" offsetY="0" delay="80"/>
+			<frame index="2" offsetY="0" delay="80"/>
+			<frame index="3" offsetY="0" delay="80"/>
+			<frame index="4" offsetY="0" delay="80"/>
+			<frame index="5" offsetY="0" delay="80"/>
+			<frame index="6" offsetY="0" delay="80"/>
+			<frame index="7" offsetY="0" delay="80"/>
+			<frame index="8" offsetY="0" delay="80"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-red-rotating-hex.xml
+++ b/graphics/sprites/icon-red-rotating-hex.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/particles/hex-facet-50.png|W:#ff0000" width="9" height="11" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetX="-2" offsetY="-16" delay="120"/>
-			<frame index="1" offsetX="-2" offsetY="-16" delay="120"/>
-			<frame index="2" offsetX="-2" offsetY="-16" delay="120"/>
-			<frame index="3" offsetX="-2" offsetY="-16" delay="120"/>
-			<frame index="4" offsetX="-2" offsetY="-16" delay="120"/>
-			<frame index="5" offsetX="-3" offsetY="-16" delay="120"/>
-			<frame index="6" offsetX="-2" offsetY="-16" delay="120"/>
-			<frame index="7" offsetX="-2" offsetY="-16" delay="120"/>
+			<frame index="0" offsetX="-2" offsetY="4" delay="120"/>
+			<frame index="1" offsetX="-2" offsetY="4" delay="120"/>
+			<frame index="2" offsetX="-2" offsetY="4" delay="120"/>
+			<frame index="3" offsetX="-2" offsetY="4" delay="120"/>
+			<frame index="4" offsetX="-2" offsetY="4" delay="120"/>
+			<frame index="5" offsetX="-3" offsetY="4" delay="120"/>
+			<frame index="6" offsetX="-2" offsetY="4" delay="120"/>
+			<frame index="7" offsetX="-2" offsetY="4" delay="120"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-slow-poison.xml
+++ b/graphics/sprites/icon-slow-poison.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-slow-poison.png" width="12" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="190" />
-			<frame index="1" offsetY="-12" delay="275" />
-			<frame index="2" offsetY="-12" delay="300" />
+			<frame index="0" offsetY="0" delay="190" />
+			<frame index="1" offsetY="0" delay="275" />
+			<frame index="2" offsetY="0" delay="300" />
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-spell-attack-generic.xml
+++ b/graphics/sprites/icon-spell-attack-generic.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-spell-attack-generic.png" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="100"/>
+			<frame index="0" offsetY="0" delay="100"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-spell-haste.xml
+++ b/graphics/sprites/icon-spell-haste.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-spell-haste.png" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-23" delay="0"/>
+			<frame index="0" offsetY="4" delay="0"/>
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-spell-protection-generic.xml
+++ b/graphics/sprites/icon-spell-protection-generic.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-spell-protection-generic.png" width="12" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="400" />
-			<frame index="1" offsetY="-12" delay="200" />
-			<frame index="2" offsetY="-12" delay="250" />
-			<frame index="1" offsetY="-12" delay="200" />
+			<frame index="0" offsetY="0" delay="400" />
+			<frame index="1" offsetY="0" delay="200" />
+			<frame index="2" offsetY="0" delay="250" />
+			<frame index="1" offsetY="0" delay="200" />
 		</animation>
 	</action>
 </sprite>

--- a/graphics/sprites/icon-spell-shearing.xml
+++ b/graphics/sprites/icon-spell-shearing.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <sprite>
 	<imageset name="base" src="graphics/sprites/icon-spell-shearing.png" width="13" height="20" />
-	
+
 	<action name="default" imageset="base">
 		<animation direction="default">
-			<frame index="0" offsetY="-12" delay="100"/>
+			<frame index="0" offsetY="0" delay="100"/>
 		</animation>
 	</action>
 </sprite>


### PR DESCRIPTION
The new client is handling sprites in a unified way regarding
the Y offset. Thus, icons, which are sprites, had to be adapted.
We decided to simplify the offset in the new client so that
the handling there is more simple in the long term.

The icon will have an offset in the 0.5.x clients but it should
still be bearable.
