### PR TITLE
Tiled Automapping rules adapted.

### DIFF
--- a/rules/cave/rule_cave.txt
+++ b/rules/cave/rule_cave.txt
@@ -4,8 +4,6 @@
 # Rules for caves
 
 # basic stuff: each rule-tile gets a default tile
-# here is a map attribute set: "DeleteTiles := true" This means to delete all
-# tiles in all touched tileslayers first.
 ./rule_cave_001.tmx
 
 # straight walls:

--- a/rules/cave/rule_cave_001.tmx
+++ b/rules/cave/rule_cave_001.tmx
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="orthogonal" width="17" height="17" tilewidth="32" tileheight="32">
- <properties>
-  <property name="AutomappingRadius" value="1"/>
-  <property name="DeleteTiles" value="true"/>
- </properties>
  <tileset firstgid="1" name="collision" tilewidth="32" tileheight="32">
   <image source="../../graphics/tiles/collision.png" width="64" height="32"/>
  </tileset>

--- a/rules/example_cave.tmx
+++ b/rules/example_cave.tmx
@@ -17,8 +17,8 @@
   <image source="../graphics/tiles/set_rules.png" width="64" height="64"/>
  </tileset>
  <layer name="set" width="64" height="32">
-  <data encoding="base64" compression="gzip">
-   H4sIAAAAAAAAA+2VTQuDMAyGOzoPY/MgbJfd3P//kSIoK6Ok+WjaOHN4EMXaPm9qOoQQBsdxHCVeBtbQmkuB3uvr5X2UDOKGlrv1HCj+XG/L/jXqPp3Av+Q2J6z37xP6fxJ/TP2PlAu1/pgMpP6t88v53BDZaPUFC/61SOfA+nFzjEH33NfMTOofM3AzgJ6V/CnZQu9Q93DOn5IBVAvpHsX4zQmTIX9ovvt2xY7B+lPdORlI+/b63Ssx5xpnQw1/Si+C5nkY88fC6cm52j/D9z+gzvkP/tz+0jsDifvuj6m51T0g/f+567eyB3r5W+F3/aNwvOM4jtOeBUMtORIAIAAA
+  <data encoding="base64" compression="zlib">
+   eJztlU0LgzAMhjs6D2PzIGyX3dz//5EiKCujpPlo2jhzeBDF2j5vajqEEAbHcRwlXgbW0JpLgd7r6+V9lAzihpa79Rwo/lxvy/416j6dwL/kNies9+8T+n8Sf0z9j5QLtf6YDKT+rfPL+dwQ2Wj1BQv+tUjnwPpxc4xB99zXzEzqHzNwM4Celfwp2ULvUPdwzp+SAVQL6R7F+M0JkyF/aL77dsWOwfpT3TkZSPv2+t0rMecaZ0MNf0ovguZ5GPPHwunJudo/w/c/oM75D/7c/tI7A4n77o+pudU9IP3/ueu3sgd6+Vvhd/2jcLzjOI7TngW7oCR0
   </data>
  </layer>
 </map>

--- a/rules/firstrule.tmx
+++ b/rules/firstrule.tmx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
+<map version="1.0" orientation="orthogonal" width="32" height="32" tilewidth="32" tileheight="32">
+ <properties>
+  <property name="DeleteTiles" value="true"/>
+ </properties>
+ <layer name="ruleset" width="32" height="32">
+  <data encoding="base64" compression="zlib">
+   eJztwQENAAAAwqD3T20PBxQAAADwbhAAAAE=
+  </data>
+ </layer>
+ <layer name="ruleregions" width="32" height="32">
+  <data encoding="base64" compression="zlib">
+   eJztwQENAAAAwqD3T20PBxQAAADwbhAAAAE=
+  </data>
+ </layer>
+ <layer name="rule_Ground" width="32" height="32">
+  <data encoding="base64" compression="zlib">
+   eJztwQENAAAAwqD3T20PBxQAAADwbhAAAAE=
+  </data>
+ </layer>
+ <layer name="rule_Fringe" width="32" height="32">
+  <data encoding="base64" compression="zlib">
+   eJztwQENAAAAwqD3T20PBxQAAADwbhAAAAE=
+  </data>
+ </layer>
+ <layer name="rule_Over" width="32" height="32">
+  <data encoding="base64" compression="zlib">
+   eJztwQENAAAAwqD3T20PBxQAAADwbhAAAAE=
+  </data>
+ </layer>
+ <layer name="rule_Over2" width="32" height="32">
+  <data encoding="base64" compression="zlib">
+   eJztwQENAAAAwqD3T20PBxQAAADwbhAAAAE=
+  </data>
+ </layer>
+</map>

--- a/rules/icecave/rule_icecave_001.tmx
+++ b/rules/icecave/rule_icecave_001.tmx
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="orthogonal" width="9" height="9" tilewidth="32" tileheight="32">
- <properties>
-  <property name="AutoMappingRadius" value="1"/>
-  <property name="DeleteTiles" value="true"/>
- </properties>
  <tileset firstgid="1" name="collision" tilewidth="32" tileheight="32">
   <image source="../../graphics/tiles/collision.png" width="64" height="32"/>
  </tileset>

--- a/rules/icemountain/rule_icemountain_001.tmx
+++ b/rules/icemountain/rule_icemountain_001.tmx
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="orthogonal" width="15" height="5" tilewidth="32" tileheight="32">
- <properties>
-  <property name="AutomappingRadius" value="5"/>
-  <property name="DeleteTiles" value="true"/>
- </properties>
  <tileset firstgid="1" name="set_icemountain" tilewidth="32" tileheight="32">
   <image source="../../graphics/tiles/set_icemountain.png" width="224" height="128"/>
  </tileset>

--- a/rules/rules.txt
+++ b/rules/rules.txt
@@ -1,6 +1,8 @@
 # lines starting with # or // are comments
 # all other lines will be parsed and treated as filenames.
 
+../rules/firstrule.tmx
+
 ../rules/cave/rule_cave.txt
 
 ../rules/icecave/rule_icecave.txt

--- a/rules/thermin_cave/rule001.tmx
+++ b/rules/thermin_cave/rule001.tmx
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="orthogonal" width="15" height="11" tilewidth="32" tileheight="32">
- <properties>
-  <property name="AutomappingRadius" value="3"/>
-  <property name="DeleteTiles" value="yes"/>
- </properties>
  <tileset firstgid="1" name="collision" tilewidth="32" tileheight="32">
   <image source="../../graphics/tiles/collision.png" width="64" height="32"/>
  </tileset>

--- a/rules/woodland/rule_woodland_001.tmx
+++ b/rules/woodland/rule_woodland_001.tmx
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map SYSTEM "http://mapeditor.org/dtd/1.0/map.dtd">
 <map version="1.0" orientation="orthogonal" width="33" height="17" tilewidth="32" tileheight="32">
- <properties>
-  <property name="DeleteTiles" value="true"/>
- </properties>
  <tileset firstgid="1" name="Woodland" tilewidth="32" tileheight="32">
   <image source="../../graphics/tiles/Woodland_ground.png" width="512" height="512"/>
  </tileset>


### PR DESCRIPTION
The DeleteTiles attribute must not occur in each terrain type, but at the beginning of the whole Automapping in the very first rule.
