### PR TITLE
Typo fix for 055-1.tmx

### DIFF
--- a/maps/019-4.tmx
+++ b/maps/019-4.tmx
@@ -40,7 +40,7 @@
     <property name="dest_y" value="1408"/>
    </properties>
   </object>
-  <object name="Spawn Mogguns" type="spawn" x="0" y="0">
+  <object name="Moggun" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="30000"/>
     <property name="eA_spawn" value="45000"/>
@@ -48,7 +48,7 @@
     <property name="monster_id" value="59"/>
    </properties>
   </object>
-  <object name="Spawn White Slime" type="spawn" x="1292" y="2024" width="523" height="329">
+  <object name="White Slime" type="spawn" x="1292" y="2024" width="523" height="329">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="45000"/>
@@ -56,7 +56,7 @@
     <property name="monster_id" value="91"/>
    </properties>
   </object>
-  <object name="Spawn Bat" type="spawn" x="0" y="0">
+  <object name="Bat" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="25000"/>
     <property name="eA_spawn" value="45000"/>
@@ -64,7 +64,7 @@
     <property name="monster_id" value="15"/>
    </properties>
   </object>
-  <object name="Spawn Blue Slimes" type="spawn" x="0" y="0">
+  <object name="Blue Slime" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="30000"/>
     <property name="eA_spawn" value="45000"/>

--- a/maps/055-1.tmx
+++ b/maps/055-1.tmx
@@ -54,7 +54,7 @@
     <property name="dest_y" value="1312"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="1836" y="2036" width="750" height="654">
+  <object name="Butterfly" type="spawn" x="1836" y="2036" width="750" height="654">
    <properties>
     <property name="eA_death" value="85000"/>
     <property name="eA_spawn" value="10000"/>
@@ -69,7 +69,7 @@
     <property name="dest_y" value="1632"/>
    </properties>
   </object>
-  <object name="Spawn Silk Worm" type="spawn" x="1928" y="724" width="1794" height="494">
+  <object name="Silkworm" type="spawn" x="1928" y="724" width="1794" height="494">
    <properties>
     <property name="eA_death" value="85000"/>
     <property name="eA_spawn" value="10000"/>
@@ -77,7 +77,7 @@
     <property name="monster_id" value="33"/>
    </properties>
   </object>
-  <object name="Spawn Squirrel" type="spawn" x="1204" y="716" width="2750" height="602">
+  <object name="Squirrel" type="spawn" x="1204" y="716" width="2750" height="602">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -85,7 +85,7 @@
     <property name="monster_id" value="36"/>
    </properties>
   </object>
-  <object name="Spawn Mouboo" type="spawn" x="0" y="0">
+  <object name="Mouboo" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="85000"/>
     <property name="eA_spawn" value="10000"/>
@@ -93,7 +93,7 @@
     <property name="monster_id" value="26"/>
    </properties>
   </object>
-  <object name="Spawn Clover Patch" type="spawn" x="2819" y="1511" width="244" height="180">
+  <object name="Clover Patch" type="spawn" x="2819" y="1511" width="244" height="180">
    <properties>
     <property name="eA_death" value="180000"/>
     <property name="eA_spawn" value="10000"/>
@@ -101,7 +101,7 @@
     <property name="monster_id" value="35"/>
    </properties>
   </object>
-  <object name="Spawn Clover Patch" type="spawn" x="3235" y="1724" width="213" height="157">
+  <object name="Clover Patch" type="spawn" x="3235" y="1724" width="213" height="157">
    <properties>
     <property name="eA_death" value="180000"/>
     <property name="eA_spawn" value="10000"/>
@@ -109,7 +109,7 @@
     <property name="monster_id" value="35"/>
    </properties>
   </object>
-  <object name="Spawn Clover Patch" type="spawn" x="1653" y="2164" width="916" height="548">
+  <object name="Clover Patch" type="spawn" x="1653" y="2164" width="916" height="548">
    <properties>
     <property name="eA_death" value="120000"/>
     <property name="eA_spawn" value="10000"/>
@@ -117,7 +117,7 @@
     <property name="monster_id" value="35"/>
    </properties>
   </object>
-  <object name="Spawn snail" type="spawn" x="1268" y="714" width="2681" height="833">
+  <object name="snail" type="spawn" x="1268" y="714" width="2681" height="833">
    <properties>
     <property name="eA_death" value="85000"/>
     <property name="eA_spawn" value="10000"/>
@@ -125,7 +125,7 @@
     <property name="monster_id" value="39"/>
    </properties>
   </object>
-  <object name="Spawn Alizarin Plant" type="spawn" x="1993" y="1936" width="588" height="806">
+  <object name="Alizarin Plant" type="spawn" x="1993" y="1936" width="588" height="806">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>
@@ -133,7 +133,7 @@
     <property name="monster_id" value="30"/>
    </properties>
   </object>
-  <object name="Spawn Alizarin Plant" type="spawn" x="1329" y="702" width="2628" height="746">
+  <object name="Alizarin Plant" type="spawn" x="1329" y="702" width="2628" height="746">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>
@@ -141,7 +141,7 @@
     <property name="monster_id" value="30"/>
    </properties>
   </object>
-  <object name="Spawn Mauve Plant" type="spawn" x="0" y="0">
+  <object name="Mauve Plant" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="55000"/>
     <property name="eA_spawn" value="10000"/>
@@ -149,7 +149,7 @@
     <property name="monster_id" value="27"/>
    </properties>
   </object>
-  <object name="Spawn Cobalt Plant" type="spawn" x="0" y="0">
+  <object name="Cobalt Plant" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>
@@ -157,7 +157,7 @@
     <property name="monster_id" value="28"/>
    </properties>
   </object>
-  <object name="Spawn Gamboge Plant" type="spawn" x="0" y="0">
+  <object name="Gamboge Plant" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>
@@ -165,7 +165,7 @@
     <property name="monster_id" value="29"/>
    </properties>
   </object>
-  <object name="Spawn Pink Flower" type="spawn" x="3678" y="1896" width="188" height="126">
+  <object name="Pink Flower" type="spawn" x="3678" y="1896" width="188" height="126">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -173,7 +173,7 @@
     <property name="monster_id" value="12"/>
    </properties>
   </object>
-  <object name="Spawn Pink Flower" type="spawn" x="3049" y="1908" width="183" height="116">
+  <object name="Pink Flower" type="spawn" x="3049" y="1908" width="183" height="116">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -181,7 +181,7 @@
     <property name="monster_id" value="12"/>
    </properties>
   </object>
-  <object name="Spawn Pink Flower" type="spawn" x="1708" y="2109" width="787" height="590">
+  <object name="Pink Flower" type="spawn" x="1708" y="2109" width="787" height="590">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -210,7 +210,7 @@
     <property name="dest_y" value="2400"/>
    </properties>
   </object>
-  <object name="Spawn Spiky Mushroom" type="spawn" x="0" y="0">
+  <object name="Spiky Mushroom" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>

--- a/maps/055-3.tmx
+++ b/maps/055-3.tmx
@@ -87,7 +87,7 @@
   <object name="graphics/particles/flame.particle.xml" type="particle_effect" x="3904" y="3520" width="32" height="32"/>
   <object name="graphics/particles/flame.particle.xml" type="particle_effect" x="3840" y="2624" width="32" height="32"/>
   <object name="graphics/particles/flame.particle.xml" type="particle_effect" x="3232" y="2112" width="32" height="32"/>
-  <object name="Spawn Red Slime" type="spawn" x="1125" y="1201" width="681" height="486">
+  <object name="Red Slime" type="spawn" x="1125" y="1201" width="681" height="486">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>
@@ -95,7 +95,7 @@
     <property name="monster_id" value="6"/>
    </properties>
   </object>
-  <object name="Spawn Bats" type="spawn" x="0" y="0" width="32" height="32">
+  <object name="Bat" type="spawn" x="0" y="0" width="32" height="32">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -103,7 +103,7 @@
     <property name="monster_id" value="15"/>
    </properties>
   </object>
-  <object name="Spawn Yellow Slime" type="spawn" x="1265" y="1774" width="936" height="1343">
+  <object name="Yellow Slime" type="spawn" x="1265" y="1774" width="936" height="1343">
    <properties>
     <property name="eA_death" value="60000"/>
     <property name="eA_spawn" value="10000"/>
@@ -111,7 +111,7 @@
     <property name="monster_id" value="5"/>
    </properties>
   </object>
-  <object name="Spawn Black Scorpion" type="spawn" x="0" y="0" width="32" height="32">
+  <object name="Black Scorpion" type="spawn" x="0" y="0" width="32" height="32">
    <properties>
     <property name="eA_death" value="35000"/>
     <property name="eA_spawn" value="10000"/>
@@ -119,7 +119,7 @@
     <property name="monster_id" value="7"/>
    </properties>
   </object>
-  <object name="Spawn Spider" type="spawn" x="0" y="0" width="32" height="32">
+  <object name="Spider" type="spawn" x="0" y="0" width="32" height="32">
    <properties>
     <property name="eA_death" value="35000"/>
     <property name="eA_spawn" value="10000"/>
@@ -127,7 +127,7 @@
     <property name="monster_id" value="10"/>
    </properties>
   </object>
-  <object name="Spawn Snake" type="spawn" x="0" y="0" width="32" height="32">
+  <object name="Snake" type="spawn" x="0" y="0" width="32" height="32">
    <properties>
     <property name="eA_death" value="20000"/>
     <property name="eA_spawn" value="10000"/>

--- a/maps/056-1.tmx
+++ b/maps/056-1.tmx
@@ -62,7 +62,7 @@
     <property name="dest_y" value="1792"/>
    </properties>
   </object>
-  <object name="Spawn Evil Mushroom" type="spawn" x="0" y="0">
+  <object name="Evil Mushroom" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -70,7 +70,7 @@
     <property name="monster_id" value="11"/>
    </properties>
   </object>
-  <object name="Spawn Log Head" type="spawn" x="0" y="0">
+  <object name="Log Head" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -78,7 +78,7 @@
     <property name="monster_id" value="23"/>
    </properties>
   </object>
-  <object name="Spawn Mauve Herb" type="spawn" x="0" y="0">
+  <object name="Mauve Plant" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="85000"/>
     <property name="eA_spawn" value="10000"/>

--- a/maps/057-1.tmx
+++ b/maps/057-1.tmx
@@ -52,7 +52,7 @@
   </data>
  </layer>
  <objectgroup name="Objects" width="170" height="124" visible="0">
-  <object name="Spawn Mauve Plant" type="spawn" x="0" y="0">
+  <object name="Mauve Plant" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="45000"/>
@@ -60,7 +60,7 @@
     <property name="monster_id" value="27"/>
    </properties>
   </object>
-  <object name="Spawn Cobalt" type="spawn" x="0" y="0">
+  <object name="Cobalt" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="65000"/>
     <property name="eA_spawn" value="10000"/>
@@ -68,7 +68,7 @@
     <property name="monster_id" value="28"/>
    </properties>
   </object>
-  <object name="Spawn Gamboge" type="spawn" x="0" y="0">
+  <object name="Gamboge" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -76,7 +76,7 @@
     <property name="monster_id" value="29"/>
    </properties>
   </object>
-  <object name="Spawn Alizarin" type="spawn" x="0" y="0">
+  <object name="Alizarin" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="70000"/>
     <property name="eA_spawn" value="10000"/>
@@ -84,7 +84,7 @@
     <property name="monster_id" value="30"/>
    </properties>
   </object>
-  <object name="Spawn Mouboo" type="spawn" x="0" y="0">
+  <object name="Mouboo" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -92,7 +92,7 @@
     <property name="monster_id" value="26"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="2592" y="1239" width="986" height="338">
+  <object name="Butterfly" type="spawn" x="2592" y="1239" width="986" height="338">
    <properties>
     <property name="eA_death" value="40000"/>
     <property name="eA_spawn" value="10000"/>
@@ -100,7 +100,7 @@
     <property name="monster_id" value="53"/>
    </properties>
   </object>
-  <object name="Spawn Silkworm" type="spawn" x="666" y="823" width="410" height="1518">
+  <object name="Silkworm" type="spawn" x="666" y="823" width="410" height="1518">
    <properties>
     <property name="eA_death" value="15000"/>
     <property name="eA_spawn" value="10000"/>
@@ -108,7 +108,7 @@
     <property name="monster_id" value="33"/>
    </properties>
   </object>
-  <object name="Spawn Pink Flower" type="spawn" x="2845" y="1052" width="764" height="553">
+  <object name="Pink Flower" type="spawn" x="2845" y="1052" width="764" height="553">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -116,7 +116,7 @@
     <property name="monster_id" value="12"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="2941" y="810" width="643" height="409">
+  <object name="Butterfly" type="spawn" x="2941" y="810" width="643" height="409">
    <properties>
     <property name="eA_death" value="40000"/>
     <property name="eA_spawn" value="10000"/>
@@ -124,7 +124,7 @@
     <property name="monster_id" value="53"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="2467" y="1874" width="433" height="440">
+  <object name="Butterfly" type="spawn" x="2467" y="1874" width="433" height="440">
    <properties>
     <property name="eA_death" value="40000"/>
     <property name="eA_spawn" value="10000"/>
@@ -132,7 +132,7 @@
     <property name="monster_id" value="53"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="1775" y="952" width="305" height="392">
+  <object name="Butterfly" type="spawn" x="1775" y="952" width="305" height="392">
    <properties>
     <property name="eA_death" value="40000"/>
     <property name="eA_spawn" value="10000"/>
@@ -140,7 +140,7 @@
     <property name="monster_id" value="53"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="915" y="1283" width="305" height="392">
+  <object name="Butterfly" type="spawn" x="915" y="1283" width="305" height="392">
    <properties>
     <property name="eA_death" value="40000"/>
     <property name="eA_spawn" value="10000"/>
@@ -148,7 +148,7 @@
     <property name="monster_id" value="53"/>
    </properties>
   </object>
-  <object name="Spawn Butterfly" type="spawn" x="4435" y="934" width="433" height="440">
+  <object name="Butterfly" type="spawn" x="4435" y="934" width="433" height="440">
    <properties>
     <property name="eA_death" value="40000"/>
     <property name="eA_spawn" value="10000"/>
@@ -156,7 +156,7 @@
     <property name="monster_id" value="53"/>
    </properties>
   </object>
-  <object name="Spawn Pink Flower" type="spawn" x="3139" y="2014" width="426" height="385">
+  <object name="Pink Flower" type="spawn" x="3139" y="2014" width="426" height="385">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -164,7 +164,7 @@
     <property name="monster_id" value="12"/>
    </properties>
   </object>
-  <object name="Spawn Pink Flower" type="spawn" x="4129" y="1538" width="426" height="385">
+  <object name="Pink Flower" type="spawn" x="4129" y="1538" width="426" height="385">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -172,7 +172,7 @@
     <property name="monster_id" value="12"/>
    </properties>
   </object>
-  <object name="Spawn Spiky Mushroom" type="spawn" x="0" y="0">
+  <object name="Spiky Mushroom" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="45000"/>
     <property name="eA_spawn" value="10000"/>
@@ -187,7 +187,7 @@
     <property name="dest_y" value="2016"/>
    </properties>
   </object>
-  <object name="Spawn Clover Patch" type="spawn" x="0" y="0">
+  <object name="Clover Patch" type="spawn" x="0" y="0">
    <properties>
     <property name="eA_death" value="180000"/>
     <property name="eA_spawn" value="10000"/>
@@ -195,7 +195,7 @@
     <property name="monster_id" value="35"/>
    </properties>
   </object>
-  <object name="Spawn Squirrel" type="spawn" x="640" y="640" width="488" height="1704">
+  <object name="Squirrel" type="spawn" x="640" y="640" width="488" height="1704">
    <properties>
     <property name="eA_death" value="50000"/>
     <property name="eA_spawn" value="10000"/>


### PR DESCRIPTION
I just changed "Spawn Spikey Mushroom" to "Spawn Spiky Mushroom",
which is a typo fix. I find out this typo when debugging why #chipchip
not work in new maps recently added.

I'll push a commit to server data repository too, which fix the #chipchip
problem with an ugly method. To actually fix the #chipchip problem with
an elegant method, someone should remove "Spawn " from all spawn object
names in maps, and don't add "Spawn " in the spawn object names again
for future maps.
