### PR TITLE
paths.xml content is now read from settings.xml in Mana client

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -3,6 +3,7 @@
     It defines all the settings, and can include additional XML files for this.
 -->
 <settings>
+	<include file="paths.xml" />
 	<include file="maps.xml" />
 	<include file="skills.xml" />
 	<include file="items.xml" />


### PR DESCRIPTION
paths.xml content was moved into settings.xml in Mana.

To keep the compatibility, paths.xml must be included from settings.xml
