### PR TITLE
Increasing respawn time for Terranites

### DIFF
--- a/maps/043-4.tmx
+++ b/maps/043-4.tmx
@@ -1029,7 +1029,7 @@
 2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2
 </data>
  </layer>
- <objectgroup name="Objects" visible="0">
+ <objectgroup name="Objects" width="0" height="0" visible="0">
   <object name="graphics/particles/flame.particle.xml" type="particle_effect" x="1632" y="1376" width="32" height="32"/>
   <object name="graphics/particles/flame.particle.xml" type="particle_effect" x="1632" y="1216" width="32" height="32"/>
   <object name="graphics/particles/flame.particle.xml" type="particle_effect" x="1440" y="1216" width="32" height="32"/>
@@ -1046,8 +1046,8 @@
   </object>
   <object name="Terranite" type="spawn" x="4362" y="5144" width="265" height="247">
    <properties>
-    <property name="eA_death" value="100000"/>
-    <property name="eA_spawn" value="200000"/>
+    <property name="eA_death" value="120000"/>
+    <property name="eA_spawn" value="240000"/>
     <property name="max_beings" value="2"/>
     <property name="monster_id" value="60"/>
    </properties>


### PR DESCRIPTION
...because Terranites in the Troll Cave were meant to be an alternative to the PvP Terranite Cave and not as main grinding point. The respawn time was still a bit too fast therefore.
