### PR TITLE
Fixing Bucket stats in its items.xml

### DIFF
--- a/items/equip-head/item905_BucketHat.xml
+++ b/items/equip-head/item905_BucketHat.xml
@@ -6,7 +6,7 @@
     <its:translateRule selector="//item/@effect" translate="yes"/>
     <its:translateRule selector="//*" translate="no"/>
   </its:rules>
-  <item id="905" image="equipment/head/bucket.png" name="Bucket" description="A Bucket for your head." effect="M. Attack +4" type="equip-head" defense="1" weight="1">
+  <item id="905" image="equipment/head/bucket.png" name="Bucket" description="A Bucket for your head." type="equip-head" defense="5" weight="20">
     <sprite gender="male">equipment/head/bucket-male.xml</sprite>
     <sprite gender="female">equipment/head/bucket-female.xml</sprite>
   </item>


### PR DESCRIPTION
Bucket's items.xml showed wrong stats in DEF, weight and magic attack. Fixed.
[19:46:11] Cassy wushin: btw, item_db and items.xml for the Bucket Hat are different (weight, DEF, M.Att.)... if you tell me which of them are correct I'll fix it
[19:47:09] Cassy s/are/is/
[19:48:19] wushin server-data is
