### PR TITLE
Making Reinboo use the correct base sprite

### DIFF
--- a/monsters/monster1094_Reinboo.xml
+++ b/monsters/monster1094_Reinboo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <monsters offset="0">
   <monster id="1094" name="Reinboo">
-    <sprite>monsters/mouboo.xml</sprite>
+    <sprite>monsters/christmas-mouboo.xml</sprite>
     <sprite>monsters/accessories/mouboo-red-nose.xml</sprite>
     <sprite>monsters/accessories/mouboo-red-saddle.xml</sprite>
     <sprite>monsters/accessories/mouboo-red-shoes.xml</sprite>


### PR DESCRIPTION
Reinboo used the standard Mouboo sprite instead of the Christmas Mouboo one so it had two noses. Fixed that.