### PR TITLE
[WIP] Fixes in translation generation (itstool)

### DIFF
--- a/monsters/_monsters.its
+++ b/monsters/_monsters.its
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ITS rules for "monsters/monster*.xml" files. -->
+<its:rules xmlns:its="http://www.w3.org/2005/11/its" version="1.0">
+    <!-- Ignore translations for all xpaths... -->
+    <its:translateRule selector="//*" translate="no"/>
+    <!-- ...except the name of the monster (as attribute and element) -->
+    <its:translateRule selector="//monster/@name" translate="yes"/>
+    <its:translateRule selector="//monster/name" translate="yes"/>
+
+    <!-- Description for translators -->
+    <its:locNoteRule selector="//monster/name | //monster/@name"
+        locNoteType="description">
+      <its:locNote>Monster's name</its:locNote>
+    </its:locNoteRule>
+</its:rules>


### PR DESCRIPTION
This will fix issues on including unnecessary strings to be translated, like in `monsters/*.xml` (#299)
- [x] :one: Ignore strings that should not be translated from XML files (**_monsters**_), by adding ITS rules. _Only "name" attribute/element are collected for translation_. <br/> Rules for Monsters are in `monsters/_monsters.its` file, and can be used by running:

``` bash
$ itstool monsters/monster*.xml -o "monsters.pot" -i "monsters/_monsters.its"
```
- [ ] :two::question: Insert ITS rules directly in *.xml files to do not use `-i` command line option. Then, translatable strings can be collected just by runnig:

``` bash
$ itstool monsters/monster*.xml -o "monsters.pot"
```
### Feedbacks
- **Is it really needed :two: or :one: is enough?** (Check https://github.com/nelson6e65/tmwa-client-data/commit/f3869925730d1c868d53987d5c423d03b59c10a0). <br/> I think :two: is unnecessary, and with only :one: the `*.xml`s kept simple and untouched. But I don't know how @4144 collect the strings exactly.
